### PR TITLE
Add pay2go

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -6,6 +6,10 @@ class OrdersController < ApplicationController
     @orders = current_user.orders
   end
 
+  def show
+    @order = current_user.orders.find( params[:id] )
+  end
+
   def new
     @order = Order.new
 
@@ -21,10 +25,22 @@ class OrdersController < ApplicationController
 
     if @order.save
       session[:cart_id] = nil
-      
-      redirect_to orders_path
+
+      redirect_to order_path(@order)
     else
       render "new"
+    end
+  end
+
+  def checkout_pay2go
+    @order = current_user.orders.find(params[:id])
+
+    if @order.paid?
+      redirect_to :back, alert: 'already paid!'
+    else
+      @payment = Payment.create!( :order => @order,
+                                  :payment_method => params[:payment_method] )
+      render :layout => false
     end
   end
 

--- a/app/controllers/pay2go_controller.rb
+++ b/app/controllers/pay2go_controller.rb
@@ -1,0 +1,44 @@
+class Pay2goController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def return
+    result = nil
+    ActiveRecord::Base.transaction do
+      @payment = Payment.find_and_process( json_data )
+      result = @payment.save
+    end
+
+    unless result
+      flash[:alert] = t("registration.error.failed_pay")
+    end
+
+    @order = @payment.order
+
+    if @payment.paid?
+     # send paid email
+    end
+
+    redirect_to order_path(@order)
+  end
+
+  def notify
+    result = nil
+    ActiveRecord::Base.transaction do
+      @payment = PaymentPay2go.find_and_process( json_data )
+      result = @payment.save
+    end
+
+    if result
+      render :text => "1|OK"
+    else
+      render :text => "0|ErrorMessage"
+    end
+  end
+
+  private
+
+  def json_data
+    JSON.parse( params["JSONData"] )
+  end
+
+end

--- a/app/helpers/pay2go_helper.rb
+++ b/app/helpers/pay2go_helper.rb
@@ -1,0 +1,42 @@
+module Pay2goHelper
+
+  def generate_pay2go_params(payment)
+      pay2go_params = {
+        MerchantID: Pay2go.merchant_id,
+        RespondType: "JSON",
+        TimeStamp: payment.created_at.to_i,
+        Version: "1.2",
+        LangType: I18n.locale.downcase, # zh-tw or en
+        MerchantOrderNo: payment.external_id,
+        Amt: payment.amount,
+        ItemDesc: payment.name,
+        ReturnURL: pay2go_return_url,
+        NotifyURL: Pay2go.notify_url,
+        Email: payment.email,
+        LoginType: 0,
+        CREDIT: 0,
+        WEBATM: 0,
+        VACC: 0,
+        CVS: 0,
+        BARCODE: 0
+      }
+
+      case payment.payment_method
+        when "Credit"
+          pay2go_params.merge!( :CREDIT => 1 )
+        when "WebATM"
+          pay2go_params.merge!( :WEBATM => 1 )
+        when "ATM"
+          pay2go_params.merge!( :VACC => 1, :ExpireDate => payment.deadline.strftime("%Y%m%d") )
+        when "CVS"
+          pay2go_params.merge!( :CVS => 1, :ExpireDate => payment.deadline.strftime("%Y%m%d") )
+        when "BARCODE"
+          pay2go_params.merge!( :BARCODE => 1, :ExpireDate => payment.deadline.strftime("%Y%m%d") )
+      end
+
+      pay2go = Pay2go.new(pay2go_params)
+      pay2go_params[:CheckValue] = pay2go.make_check_value
+      pay2go_params
+  end
+
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,6 +5,8 @@ class Order < ActiveRecord::Base
   belongs_to :user
   has_many :line_items
 
+  has_many :payments
+
   def add_line_items(cart)
     cart.line_items.each do |line|
       self.line_items.build( :product => line.product, :qty => line.qty )

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -1,0 +1,63 @@
+class Payment < ActiveRecord::Base
+
+  serialize :params, JSON
+
+  belongs_to :order
+
+  before_validation :setup_amount
+  after_update :update_order_status
+
+  PAYMENT_METHODS = %w[Credit WebATM ATM] # CVS BARCODE
+  validates_inclusion_of :payment_method, :in => PAYMENT_METHODS
+
+  validate :check_mac, on: :update
+
+  def deadline
+    Time.now + 7.days
+  end
+
+  def name
+    "ALPHACamp AC6 Order: #{self.order.id}"
+  end
+
+  def email
+    order.email
+  end
+
+  def external_id
+    "#{self.id}AC#{Rails.env.upcase[0]}"
+  end
+
+  def self.find_and_process(params)
+    result = JSON.parse( params['Result'] )
+
+    payment = self.find(result['MerchantOrderNo'].to_i)
+    payment.paid = params['Status'] == 'SUCCESS'
+    payment.params = params
+    payment
+  end
+
+  def parse_result
+    JSON.parse( self.params['Result'] )
+  end
+
+  def check_mac
+    pay2go = Pay2go.new(parse_result)
+    errors.add(:params, 'wrong mac value') unless pay2go.check_mac
+  end
+
+  private
+
+  def setup_amount
+    self.amount = order.amount
+  end
+
+  def update_order_status
+    if self.paid && !self.order.paid?
+      order.paid = true
+      order.save( :validate => false )
+    end
+  end
+
+
+end

--- a/app/views/orders/checkout_pay2go.html.erb
+++ b/app/views/orders/checkout_pay2go.html.erb
@@ -1,0 +1,10 @@
+<h1>轉址前往信用卡付款頁面，請勿關閉或離開頁面...</h1>
+
+<form action="<%= Pay2go.url %>" method="post">
+  <% generate_pay2go_params(@payment).each do |key, value| %>
+    <%= hidden_field_tag key, value %>
+  <% end %>
+
+<input type="submit" style="visibility:hidden;">
+</form>
+<script>document.forms[0].submit()</script>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -8,7 +8,7 @@
   </tr>
 <% @orders.each do |o| %>
   <tr>
-    <td><%= o.id %></td>
+    <td><%= link_to o.id, order_path(o) %></td>
     <td>
       <% o.line_items.each do |line| %>
         <%= line.product.name %>: <%= line.qty %> 筆

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,15 @@
+<h1>我的訂單 #<%= @order.id %></h1>
+
+<% if @order.paid? %>
+
+  <p>已付款成功</p>
+
+<% else %>
+
+  <p>
+  <% Payment::PAYMENT_METHODS.each do |pm| %>
+    <%= link_to t(pm, :scope => "PaymentPay2go"), checkout_pay2go_order_path(@order, :payment_method => pm), :class => "btn btn-primary btn-lg", :method => :post %>
+  <% end %>
+  </p>
+
+<% end %>

--- a/config/initializers/pay2go.rb
+++ b/config/initializers/pay2go.rb
@@ -1,0 +1,10 @@
+require 'pay2go'
+pay2go_config = Rails.application.config_for(:pay2go)
+
+Pay2go.setup do |config|
+  config.merchant_id = pay2go_config["merchant_id"]
+  config.hash_key = pay2go_config["hash_key"]
+  config.hash_iv = pay2go_config["hash_iv"]
+  config.url = pay2go_config["url"]
+  config.notify_url = pay2go_config["notify_url"]
+end

--- a/config/pay2go.yml
+++ b/config/pay2go.yml
@@ -1,0 +1,22 @@
+# 廠商後台測試環境: https://cweb.pay2go.com
+# 信用卡測試卡號:
+# 4000-2222-2222-2222
+# 4000-1322-2222-2222
+default: &default
+  merchant_id: 1818315
+  hash_key: WYLp8TyJpf0QYJsguk16mwzPAI4CGlGC
+  hash_iv: ks2tlBcKRdAPX36r
+  url: https://capi.pay2go.com/MPG/mpg_gateway
+  notify_url: 'http://requestb.in/10i4t9h1'
+
+development:
+  <<: *default
+
+staging:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
 
+  post 'pay2go/return'
+  post 'pay2go/notify'
+
   scope :path => '/api/v1/', :module => "api_v1", :as => 'v1', :defaults => { :format => :json } do
 
     post "login" => "auth#login"
@@ -16,7 +19,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :orders
+  resources :orders do
+    member do
+      post :checkout_pay2go
+    end
+  end
 
   resources :people
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }

--- a/db/migrate/20160126121641_create_payments.rb
+++ b/db/migrate/20160126121641_create_payments.rb
@@ -1,0 +1,16 @@
+class CreatePayments < ActiveRecord::Migration
+  def change
+    create_table :payments do |t|
+
+      t.integer :order_id
+      t.string :payment_method
+      t.integer :amount
+      t.boolean :paid, :default => false
+      t.text :params
+
+      t.timestamps null: false
+    end
+
+    add_column :orders, :paid, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160107025729) do
+ActiveRecord::Schema.define(version: 20160126121641) do
 
   create_table "carts", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -82,8 +82,19 @@ ActiveRecord::Schema.define(version: 20160107025729) do
     t.string   "status"
     t.string   "payment_status"
     t.string   "shipping_status"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.boolean  "paid",            default: false
+  end
+
+  create_table "payments", force: :cascade do |t|
+    t.integer  "order_id"
+    t.string   "payment_method"
+    t.integer  "amount"
+    t.boolean  "paid",           default: false
+    t.text     "params"
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
   end
 
   create_table "people", force: :cascade do |t|

--- a/lib/pay2go.rb
+++ b/lib/pay2go.rb
@@ -1,0 +1,36 @@
+class Pay2go
+
+  mattr_accessor :merchant_id
+  mattr_accessor :hash_key
+  mattr_accessor :hash_iv
+  mattr_accessor :url
+  mattr_accessor :notify_url
+
+  def initialize(params)
+    data = params.stringify_keys
+    @params = data
+  end
+
+  def self.setup
+    yield(self)
+  end
+
+  def make_check_value
+    raw = @params.slice("Amt", "MerchantID", "MerchantOrderNo", "TimeStamp", "Version").sort.map!{|ary| "#{ary.first}=#{ary.last}"}.join('&')
+    str = "HashKey=#{hash_key}&#{raw}&HashIV=#{hash_iv}"
+    Digest::SHA256.hexdigest(str).upcase
+  end
+
+  def make_check_code
+    raw = @params.slice("Amt", "MerchantID", "MerchantOrderNo", "TradeNo").sort.map!{|ary| "#{ary.first}=#{ary.last}"}.join('&')
+    str = "HashIV=#{hash_iv}&#{raw}&HashKey=#{hash_key}"
+
+    Digest::SHA256.hexdigest(str).upcase
+  end
+
+  def check_mac
+    ( make_check_code == @params["CheckCode"] ) ||
+    ( make_check_value == @params["CheckValue"] )
+  end
+
+end

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Payment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
步驟摘要:
1. 上測試專區 https://cweb.pay2go.com 註冊企業帳號取得API串接金鑰
- 內容隨便填即可 (不過統編要記得! 下次登入還要用!... orz)
- 進入商店資料設定 -> 詳細資料 -> 拿到 Merchant ID、HashKey 和 HashIV
1. 新增 config/pay2go.yml 將 Merchant ID、HashKey 和 HashIV 填入
2. 新增 lib/pay2go.rb 和 config/initializers/pay2go.rb
   這是用來產生檢查碼程式，並在 rails 啟動時載入上述的 yml 設定 
3. 新增 Payment model，作為每次付款的紀錄 
4. 在付款畫面(例如 Orders show action) 加上付款的按鈕，按下後將前往 checkout_pay2go action
5. 新增 checkout_pay2go 的路由，以及從歐富寶回來時處理的路由
   
   post 'pay2go/return'
   post 'pay2go/notify'
   
   resources :orders do
     member do
       post :checkout_pay2go
     end
   end
6. 新增 pay2go_helper.rb, checkout_pay2go action 和 checkout_pay2go.html.erb

checkout_pay2go action 將新建一筆 Payment 然後自動導向歐付寶
1. 新增 pay2go_controller 的 return 和 notify

這是從歐付寶回來時的處理
